### PR TITLE
Make transactions accepted by bitcoind

### DIFF
--- a/src/bitcoin/P2pkh.mo
+++ b/src/bitcoin/P2pkh.mo
@@ -8,7 +8,6 @@ import ByteUtils "../ByteUtils";
 import Hash "../Hash";
 import Script "./Script";
 import Array "mo:base/Array";
-import Debug "mo:base/Debug";
 import Result "mo:base/Result";
 import Iter "mo:base/Iter";
 
@@ -43,14 +42,11 @@ module {
   // Map given network to its id.
   func encodeVersion(network : Types.Network) : Nat8 {
     return switch (network) {
-      case (#Bitcoin) {
+      case (#Mainnet) {
         0x00;
       };
       case (#Regtest or #Testnet) {
         0x6f;
-      };
-      case _ {
-        Debug.trap("Unsupported network.");
       };
     };
   };
@@ -87,7 +83,7 @@ module {
 
     return switch (decoded.next(), ByteUtils.read(decoded, 20, false)) {
       case (?(0x00), ?publicKeyHash) {
-        #ok {network = #Bitcoin; publicKeyHash = publicKeyHash}
+        #ok {network = #Mainnet; publicKeyHash = publicKeyHash}
       };
       case (?(0x6f), ?publicKeyHash) {
         #ok {network = #Testnet; publicKeyHash = publicKeyHash}

--- a/src/bitcoin/TxInput.mo
+++ b/src/bitcoin/TxInput.mo
@@ -12,7 +12,7 @@ module {
   // | prevTxId | prevTx output index | script | sequence |
   public func fromBytes(data : Iter.Iter<Nat8>) : Result.Result<TxInput, Text>{
     let (prevTxId, prevTxOutputIndex, script, sequence) = switch (
-      ByteUtils.read(data, 32, true),
+      ByteUtils.read(data, 32, false),
       ByteUtils.readLE32(data),
       Script.fromBytes(data, true),
       ByteUtils.readLE32(data)
@@ -60,12 +60,9 @@ module {
       var outputOffset = 0;
 
       let prevTxId = Blob.toArray(prevOutput.txid);
-      let reversedPrevTxid = Array.tabulate<Nat8>(32, func (n : Nat) {
-        prevTxId[prevTxId.size() - 1 - n];
-      });
 
       // Write prevTxId.
-      Common.copy(output, outputOffset, reversedPrevTxid, 0, 32);
+      Common.copy(output, outputOffset, prevTxId, 0, 32);
       outputOffset += 32;
 
       // Write prevTx output index.

--- a/src/bitcoin/Types.mo
+++ b/src/bitcoin/Types.mo
@@ -4,10 +4,9 @@ module {
 
   // The type of Bitcoin network.
   public type Network = {
-    #Bitcoin;
+    #Mainnet;
     #Regtest;
     #Testnet;
-    #Signet;
   };
 
   // A reference to a transaction output.
@@ -21,7 +20,6 @@ module {
     outpoint : OutPoint;
     value : Satoshi;
     height : Nat32;
-    confirmations : Nat32;
   };
 
   public type SighashType = Nat32;

--- a/src/bitcoin/Wif.mo
+++ b/src/bitcoin/Wif.mo
@@ -4,7 +4,6 @@ import Base58Check "../Base58Check";
 import ByteUtils "../ByteUtils";
 import Common "../Common";
 import Types "./Types";
-import Debug "mo:base/Debug";
 
 module {
   public type WifPrivateKey = Text;
@@ -12,14 +11,11 @@ module {
   // Map network to WIF version prefix.
   func encodeVersion(network : Types.Network) : Nat8 {
     return switch (network) {
-      case (#Bitcoin) {
+      case (#Mainnet) {
         0x80;
       };
       case (#Regtest or #Testnet) {
         0xef;
-      };
-      case _ {
-        Debug.trap("Unsupported network.");
       };
     };
   };
@@ -28,7 +24,7 @@ module {
   func decodeVersion(version : Nat8) : ?Types.Network {
     return switch (version) {
       case (0x80) {
-        ?(#Bitcoin)
+        ?(#Mainnet)
       };
       case (0xef) {
         ?(#Testnet)

--- a/test/bitcoin/bitcoinTest.mo
+++ b/test/bitcoin/bitcoinTest.mo
@@ -434,7 +434,6 @@ func testSignTransaction(testCase : SignTransactionTestCase) {
           };
           value = utxo.value;
           height = 0;
-          confirmations = 0;
         }
       };
       case _ {

--- a/test/bitcoin/bitcoinTestTools.mo
+++ b/test/bitcoin/bitcoinTestTools.mo
@@ -15,6 +15,7 @@ import Array "mo:base/Array";
 import Iter "mo:base/Iter";
 import Buffer "mo:base/Buffer";
 import Nat8 "mo:base/Nat8";
+import Nat32 "mo:base/Nat32";
 import Blob "mo:base/Blob";
 
 module {
@@ -109,7 +110,7 @@ module {
 
   // Serialize signature to DER format:
   // 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash-type]
-  func signatureToDer(signature : Signature,
+  public func signatureToDer(signature : Signature,
     sighashType : Types.SighashType) : [Nat8] {
 
     func prepSignatureMember(value : Nat) : [Nat8] {
@@ -189,7 +190,7 @@ module {
     };
 
     // sighashtype
-    output.add(0x01);
+    output.add(Nat8.fromNat(Nat32.toNat(sighashType)));
 
     return output.toArray();
   };

--- a/test/bitcoin/p2pkhTest.mo
+++ b/test/bitcoin/p2pkhTest.mo
@@ -28,7 +28,7 @@ let addressTestData : [AddressTestCase] = [
       0x8a, 0x04, 0x5f, 0xa6, 0x42, 0xb9, 0x9e, 0xa5, 0xd1
     ];
     p2pkh = "1MmqjDhakEfJd9r5BoDhPApCpA75Em17GA";
-    network = #Bitcoin;
+    network = #Mainnet;
   },
 ];
 

--- a/test/bitcoin/transactionTest.mo
+++ b/test/bitcoin/transactionTest.mo
@@ -39,7 +39,7 @@ func makeTransaction(testCase : TransactionTestCase) : Transaction.Transaction {
     func (output : TxOutput) {
       switch (PublicKey.decode(#sec1 (output.publicKey, Curves.secp256k1))) {
         case (#ok pk) {
-          switch (P2pkh.makeScript(P2pkh.deriveAddress(#Bitcoin, pk, true))) {
+          switch (P2pkh.makeScript(P2pkh.deriveAddress(#Mainnet, pk, true))) {
             case (#ok script) {
               TxOutput.TxOutput(output.amount, script)
             };


### PR DESCRIPTION
This PR:
1. remove `confirmations` from `Utxo` and `Signet` from `Network`.
2. rename `Bitcoin` to `Mainnet` in `Network`.
3. make public `signatureToDer`
4. reverse transaction id in transaction inputs
5. use `sighashType` instead of a hard-coded constant.

The main problem making bitcoind refusing transactions made with this repository was that the transaction hash in the inputs of transaction were written with the incorrect endianness, the solution I suggest in this PR is maybe not the most appropriate but it works with bitcoind.

Tests from `test/bitcoin/{bitcoinTest,transactionTest}.mo` now fail. As my changes make the transaction accepted by bitcoind while it doesn't used to be the case, I am wondering if these tests were generated with another mean than this repository.

Don't hesitate with your knowledge of this repository to put back in the standards the suggestions I made.