### PR TITLE
use https url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "motoko-sha"]
 	path = motoko-sha
-	url = git@github.com:tgalal/motoko-sha.git
+	url = https://github.com/tgalal/motoko-sha.git


### PR DESCRIPTION
I suggest to replace the submodule url with an https url (instead of ssh), which is easier for users that don't have an ssh key set up with github. We use this repo as a submodule in one of our repos and it looks like some user ran into this issue ([link](https://github.com/dfinity/examples/issues/410)). 