### PR TITLE
Better Vessel support - mo:bitcoin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "motoko-sha"]
-	path = motoko-sha
-	url = https://github.com/tgalal/motoko-sha.git

--- a/README.md
+++ b/README.md
@@ -5,13 +5,40 @@
 Pull dependencies
 
 ```
-git submodule update --init
+vessel sources
 ```
 
 Run all tests
 
 ```
 make test
+```
+
+## Vessel integration in your code
+
+### package-set.dhall
+
+```dhall
+let
+  -- This is where you can add your own packages to the package-set
+additions = [
+  { name = "sha"
+  , repo = "https://github.com/tgalal/motoko-sha"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , dependencies = ["base"] : List Text
+  },
+  { name = "bitcoin"
+  , repo = "https://github.com/tgalal/motoko-bitcoin"
+  , version = "current-version-commit-hash"
+  , dependencies = ["base", "sha"] : List Text
+  }
+] : List Package
+```
+
+### vessel.dhall
+
+```dhall
+{ dependencies = [ "base", "sha", "bitcoin" ], compiler = Some "0.6.20" }
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let
 additions = [
   { name = "sha"
   , repo = "https://github.com/tgalal/motoko-sha"
-  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , version = "a6d46445670407d51996c42892f696ed34d6296ba6d46445670407d51996c42892f696ed34d6296bsssjkkkooosfsf"
   , dependencies = ["base"] : List Text
   },
   { name = "bitcoin"
@@ -46,7 +46,7 @@ additions = [
 Base58:
 
 ```motoko
-import Base58 "src/Base58";
+import Base58 "mo:bitcoin/Base58";
 
 let encoded : Text = Base58.encode([ /* Nat8 data */ ]);
 ```
@@ -54,7 +54,7 @@ let encoded : Text = Base58.encode([ /* Nat8 data */ ]);
 Base58Check:
 
 ```motoko
-import Base58Check "src/Base58Check";
+import Base58Check "mo:bitcoin/Base58Check";
 
 let encoded : Text = Base58Check.encode([ /* Nat8 data */ ]);
 ```
@@ -62,7 +62,7 @@ let encoded : Text = Base58Check.encode([ /* Nat8 data */ ]);
 HMAC:
 
 ```motoko
-import Hmac "src/Hmac";
+import Hmac "mo:bitcoin/Hmac";
 
 let key : [Nat8] = [ /* Key bytes */ ];
 
@@ -91,7 +91,7 @@ result := hmacCustomDigest.sum();
 RIPEMD160:
 
 ```motoko
-import Ripemd160 "src/Ripemd160";
+import Ripemd160 "mo:bitcoin/Ripemd160";
 
 let digest : Ripemd160.Digest = Ripemd160.Digest();
 digest.write([ /* Nat8 data */ ]);
@@ -102,9 +102,9 @@ let result : [Nat8] = digest.sum();
 EC
 
 ```motoko
-import Jacobi "src/ec/Jacobi";
-import Affine "src/ec/Affine";
-import Curves "src/ec/Curves";
+import Jacobi "mo:bitcoin/ec/Jacobi";
+import Affine "mo:bitcoin/ec/Affine";
+import Curves "mo:bitcoin/ec/Curves";
 
 // Get secp256k1 curve parameters.
 let secp256k1 : Curves.Curve = Curves.secp256k1;
@@ -125,7 +125,7 @@ assert(Jacobi.isEqual(mul1, mul2));
 Bip32
 
 ```motoko
-import Bip32 "src/Bip32";
+import Bip32 "mo:bitcoin/Bip32";
 
 let rootKey : ?Bip32.ExtendedPublicKey = Bip32.parse("xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8", null);
 
@@ -139,7 +139,7 @@ do ? {
 Bech32:
 
 ```motoko
-import Bech32 "src/Bech32";
+import Bech32 "mo:bitcoin/Bech32";
 
 Bech32.encode("bc", [ /* Nat8 data */ ], #BECH32);
 Bech32.decode("bc", "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
@@ -148,7 +148,7 @@ Bech32.decode("bc", "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
 Segwit:
 
 ```motoko
-import Segwit "src/Segwit";
+import Segwit "mo:bitcoin/Segwit";
 
 Segwit.encode("bc", /* WitnessProgram */ );
 Segwit.decode("bc", "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");

--- a/README.md
+++ b/README.md
@@ -5,13 +5,35 @@
 Pull dependencies
 
 ```
-git submodule update --init
+vessel sources
 ```
 
 Run all tests
 
 ```
 make test
+```
+
+## Vessel integration in your code
+
+### package-set.dhall
+
+```dhall
+let
+  -- This is where you can add your own packages to the package-set
+additions = [
+  { name = "bitcoin"
+  , repo = "https://github.com/tgalal/motoko-bitcoin"
+  , version = "current-version-commit-hash"
+  , dependencies = ["base", "sha"] : List Text
+  }
+] : List Package
+```
+
+### vessel.dhall
+
+```dhall
+{ dependencies = [ "base", "sha", "bitcoin" ], compiler = Some "0.6.20" }
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let
 additions = [
   { name = "sha"
   , repo = "https://github.com/tgalal/motoko-sha"
-  , version = "a6d46445670407d51996c42892f696ed34d6296ba6d46445670407d51996c42892f696ed34d6296bsssjkkkooosfsf"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
   , dependencies = ["base"] : List Text
   },
   { name = "bitcoin"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ additions = [
   },
   { name = "bitcoin"
   , repo = "https://github.com/tgalal/motoko-bitcoin"
-  , version = "current-version-commit-hash"
+  , version = "8615a5f1b699d60b64833622cb128c20a2c8cb6b"
   , dependencies = ["base", "sha"] : List Text
   }
 ] : List Package

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ make test
 let
   -- This is where you can add your own packages to the package-set
 additions = [
+  { name = "sha"
+  , repo = "https://github.com/tgalal/motoko-sha"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , dependencies = ["base"] : List Text
+  },
   { name = "bitcoin"
   , repo = "https://github.com/tgalal/motoko-bitcoin"
   , version = "current-version-commit-hash"

--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,3 +1,32 @@
 let upstream =
   https://github.com/dfinity/vessel-package-set/releases/download/mo-0.6.20-20220131/package-set.dhall
-in upstream
+let Package =
+    { name : Text, version : Text, repo : Text, dependencies : List Text }
+
+let
+  -- This is where you can add your own packages to the package-set
+additions = [
+  { name = "sha"
+  , repo = "https://github.com/tgalal/motoko-sha"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , dependencies = ["base"] : List Text
+  }
+] : List Package
+
+
+let
+  {- This is where you can override existing packages in the package-set
+
+     For example, if you wanted to use version `v2.0.0` of the foo library:
+     let overrides = [
+         { name = "foo"
+         , version = "v2.0.0"
+         , repo = "https://github.com/bar/foo"
+         , dependencies = [] : List Text
+         }
+     ]
+  -}
+  overrides =
+    [] : List Package
+
+in  upstream # additions # overrides

--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,3 +1,37 @@
 let upstream =
   https://github.com/dfinity/vessel-package-set/releases/download/mo-0.6.20-20220131/package-set.dhall
-in upstream
+let Package =
+    { name : Text, version : Text, repo : Text, dependencies : List Text }
+
+let
+  -- This is where you can add your own packages to the package-set
+additions = [
+  { name = "sha"
+  , repo = "https://github.com/tgalal/motoko-sha"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , dependencies = ["base"] : List Text
+  },
+  { name = "sha"
+  , repo = "https://github.com/tgalal/motoko-sha"
+  , version = "a6d46445670407d51996c42892f696ed34d6296b"
+  , dependencies = ["base"] : List Text
+  }
+] : List Package
+
+
+let
+  {- This is where you can override existing packages in the package-set
+
+     For example, if you wanted to use version `v2.0.0` of the foo library:
+     let overrides = [
+         { name = "foo"
+         , version = "v2.0.0"
+         , repo = "https://github.com/bar/foo"
+         , dependencies = [] : List Text
+         }
+     ]
+  -}
+  overrides =
+    [] : List Package
+
+in  upstream # additions # overrides

--- a/package-set.dhall
+++ b/package-set.dhall
@@ -10,11 +10,6 @@ additions = [
   , repo = "https://github.com/tgalal/motoko-sha"
   , version = "a6d46445670407d51996c42892f696ed34d6296b"
   , dependencies = ["base"] : List Text
-  },
-  { name = "sha"
-  , repo = "https://github.com/tgalal/motoko-sha"
-  , version = "a6d46445670407d51996c42892f696ed34d6296b"
-  , dependencies = ["base"] : List Text
   }
 ] : List Package
 

--- a/src/Base58Check.mo
+++ b/src/Base58Check.mo
@@ -1,6 +1,6 @@
 import Array "mo:base/Array";
 import Iter "mo:base/Iter";
-import SHA256 "../motoko-sha/src/SHA256";
+import SHA256 "mo:sha/SHA256";
 import Base58 "./Base58";
 
 module {

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -1,5 +1,5 @@
 import Ripemd160 "./Ripemd160";
-import SHA256 "../motoko-sha/src/SHA256";
+import SHA256 "mo:sha/SHA256";
 
 module {
   // Applies SHA256 followed by RIPEMD160 on the given data.

--- a/src/Hmac.mo
+++ b/src/Hmac.mo
@@ -1,6 +1,6 @@
 import Array "mo:base/Array";
-import SHA256Digest "../motoko-sha/src/SHA256";
-import SHA512Digest "../motoko-sha/src/SHA512";
+import SHA256Digest "mo:sha/SHA256";
+import SHA512Digest "mo:sha/SHA512";
 
 module {
   public type Digest = {

--- a/src/bitcoin/P2pkh.mo
+++ b/src/bitcoin/P2pkh.mo
@@ -2,7 +2,7 @@ import Types "./Types";
 import EcdsaTypes "../ecdsa/Types";
 import Ecdsa "../ecdsa/Ecdsa";
 import Base58Check "../Base58Check";
-import SHA256 "../../motoko-sha/src/SHA256";
+import SHA256 "mo:sha/SHA256";
 import Ripemd160 "../Ripemd160";
 import PublicKey "../ecdsa/Publickey";
 import ByteUtils "../ByteUtils";

--- a/src/ecdsa/Ecdsa.mo
+++ b/src/ecdsa/Ecdsa.mo
@@ -2,7 +2,7 @@ import Fp "../ec/Fp";
 import Jacobi "../ec/Jacobi";
 import Common "../Common";
 import Types "./Types";
-import SHA256 "../../motoko-sha/src/SHA256";
+import SHA256 "mo:sha/SHA256";
 
 module {
   public type Signature = Types.Signature;

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,1 +1,1 @@
-{ dependencies = [ "base" ], compiler = Some "0.6.20" }
+{ dependencies = [ "base", "sha" ], compiler = Some "0.6.20" }


### PR DESCRIPTION
Hi @tgalal, I want to contribute a bit to your code. Using git submodules is not very good way to go since every repository which is based on you then has to use git submodules or local copy.

I suggest that we should convert it to way, how `motoko-base` and others are working. It also improves importing the code since you can then use only `mo:bitcoin` in import path which is similar usage as `mo:base` has.

I've also ran tests from the `Makefile` on my fork and also tested it in my testing project.

Feel free to suggest changes, correct things etc.

PS: We don't need to update `motoko-sha` since it has working support to be used as `mo:sha`.

Thanks!